### PR TITLE
Handle filenames with spaces and batch files in check-file-format check

### DIFF
--- a/scripts/githooks/check-file-format.sh
+++ b/scripts/githooks/check-file-format.sh
@@ -41,6 +41,14 @@ set -euo pipefail
 # ==============================================================================
 
 function main() {
+  if [[ ${#@} != 0 ]] && declare -f "main-tool-wrapper$1" >/dev/null 2>&1 ; then
+    "main-tool-wrapper$1" "${@:2}"
+  else
+    main-invocation "$@"
+  fi
+}
+
+function main-invocation() {
 
   cd "$(git rev-parse --show-toplevel)"
 
@@ -67,9 +75,9 @@ function main() {
   esac
 
   if command -v editorconfig > /dev/null 2>&1 && ! is-arg-true "${FORCE_USE_DOCKER:-false}"; then
-    filter="$filter" dry_run_opt="${dry_run_opt:-}" run-editorconfig-natively
+    filter="$filter" dry_run_opt="${dry_run_opt:-}" scripts/githooks/check-file-format.sh --natively
   else
-    filter="$filter" dry_run_opt="${dry_run_opt:-}" run-editorconfig-in-docker
+    filter="$filter" dry_run_opt="${dry_run_opt:-}" scripts/githooks/check-file-format.sh --via-docker
   fi
 }
 
@@ -77,7 +85,7 @@ function main() {
 # Arguments (provided as environment variables):
 #   dry_run_opt=[dry run option]
 #   filter=[git command to filter the files to check]
-function run-editorconfig-natively() {
+function main-tool-wrapper--natively() {
 
   # shellcheck disable=SC2046,SC2086
   editorconfig \
@@ -88,7 +96,7 @@ function run-editorconfig-natively() {
 # Arguments (provided as environment variables):
 #   dry_run_opt=[dry run option]
 #   filter=[git command to filter the files to check]
-function run-editorconfig-in-docker() {
+function main-tool-wrapper--via-docker() {
 
   # shellcheck disable=SC1091
   source ./scripts/docker/docker.lib.sh

--- a/scripts/githooks/check-file-format.sh
+++ b/scripts/githooks/check-file-format.sh
@@ -66,7 +66,12 @@ function main-invocation() {
     method=--via-docker
   fi
 
-  dry_run_opt="${dry_run_opt:-}" scripts/githooks/check-file-format.sh "$method" $(list-files-to-check--"$check")
+  list-files-to-check--"$check" |
+  # Maximum size of command line and environment combined is typically
+  # 2MB on Linux but only 256KB on macOS. Assume a maximum filename
+  # length of 200 characters and limiting us to batches of 1000 files
+  # gives us a bit of a safety margin.
+  dry_run_opt="${dry_run_opt:-}" xargs --max-args=1000 scripts/githooks/check-file-format.sh "$method"
 }
 
 # Run editorconfig natively.

--- a/scripts/githooks/check-file-format.sh
+++ b/scripts/githooks/check-file-format.sh
@@ -71,7 +71,7 @@ function main-invocation() {
   # 2MB on Linux but only 256KB on macOS. Assume a maximum filename
   # length of 200 characters and limiting us to batches of 1000 files
   # gives us a bit of a safety margin.
-  dry_run_opt="${dry_run_opt:-}" xargs --max-args=1000 scripts/githooks/check-file-format.sh "$method"
+  dry_run_opt="${dry_run_opt:-}" xargs --max-args=1000 --no-run-if-empty scripts/githooks/check-file-format.sh "$method"
 }
 
 # Run editorconfig natively.
@@ -96,13 +96,10 @@ function main-tool-wrapper--via-docker() {
 
   # shellcheck disable=SC2155
   local image=$(name=mstruebing/editorconfig-checker docker-get-image-version-and-pull)
-  # We use /dev/null here as a backstop in case there are no files in the state
-  # we choose. If the filter comes back empty, adding `/dev/null` onto it has
-  # the effect of preventing `ec` from treating "no files" as "all the files".
   docker run --rm --platform linux/amd64 \
     --volume "$PWD":/check \
     "$image" \
-      sh -c "ec --exclude '.git/' $dry_run_opt $(printf '%q ' "$@") /dev/null"
+      sh -c "ec --exclude '.git/' $dry_run_opt $(printf '%q ' "$@")"
 }
 
 # ==============================================================================

--- a/scripts/githooks/check-file-format.sh
+++ b/scripts/githooks/check-file-format.sh
@@ -71,7 +71,7 @@ function main-invocation() {
   # 2MB on Linux but only 256KB on macOS. Assume a maximum filename
   # length of 200 characters and limiting us to batches of 1000 files
   # gives us a bit of a safety margin.
-  dry_run_opt="${dry_run_opt:-}" xargs --max-args=1000 --no-run-if-empty scripts/githooks/check-file-format.sh "$method"
+  dry_run_opt="${dry_run_opt:-}" xargs -0 --max-args=1000 --no-run-if-empty scripts/githooks/check-file-format.sh "$method"
 }
 
 # Run editorconfig natively.
@@ -104,20 +104,23 @@ function main-tool-wrapper--via-docker() {
 
 # ==============================================================================
 
+# These all produce filenames terminated by a NUL character, so that we
+# can handle filenames that contain spaces.
+
 function list-files-to-check--all() {
-  git ls-files
+  git ls-files -z
 }
 
 function list-files-to-check--staged-changes() {
-  git diff --diff-filter=ACMRT --name-only --cached
+  git diff -z --diff-filter=ACMRT --name-only --cached
 }
 
 function list-files-to-check--working-tree-changes() {
-  git diff --diff-filter=ACMRT --name-only
+  git diff -z --diff-filter=ACMRT --name-only
 }
 
 function list-files-to-check--branch() {
-  git diff --diff-filter=ACMRT --name-only ${BRANCH_NAME:-origin/main}
+  git diff -z --diff-filter=ACMRT --name-only ${BRANCH_NAME:-origin/main}
 }
 
 # ==============================================================================

--- a/scripts/githooks/check-file-format.sh
+++ b/scripts/githooks/check-file-format.sh
@@ -75,10 +75,12 @@ function main-invocation() {
   esac
 
   if command -v editorconfig > /dev/null 2>&1 && ! is-arg-true "${FORCE_USE_DOCKER:-false}"; then
-    filter="$filter" dry_run_opt="${dry_run_opt:-}" scripts/githooks/check-file-format.sh --natively
+    method=--natively
   else
-    filter="$filter" dry_run_opt="${dry_run_opt:-}" scripts/githooks/check-file-format.sh --via-docker
+    method=--via-docker
   fi
+
+  filter="$filter" dry_run_opt="${dry_run_opt:-}" scripts/githooks/check-file-format.sh "$method"
 }
 
 # Run editorconfig natively.

--- a/scripts/githooks/check-file-format.sh
+++ b/scripts/githooks/check-file-format.sh
@@ -41,8 +41,8 @@ set -euo pipefail
 # ==============================================================================
 
 function main() {
-  if [[ ${#@} != 0 ]] && declare -f "main-tool-wrapper$1" >/dev/null 2>&1 ; then
-    "main-tool-wrapper$1" "${@:2}"
+  if [[ ${#@} != 0 ]] && declare -f "run-editorconfig$1" >/dev/null 2>&1 ; then
+    "run-editorconfig$1" "${@:2}"
   else
     main-invocation "$@"
   fi
@@ -78,7 +78,7 @@ function main-invocation() {
 # Arguments (provided as environment variables):
 #   dry_run_opt=[dry run option]
 # Arguments (provided as positional parameters): files to check
-function main-tool-wrapper--natively() {
+function run-editorconfig--natively() {
 
   # shellcheck disable=SC2046,SC2086
   editorconfig \
@@ -89,7 +89,7 @@ function main-tool-wrapper--natively() {
 # Arguments (provided as environment variables):
 #   dry_run_opt=[dry run option]
 # Arguments (provided as positional parameters): files to check
-function main-tool-wrapper--via-docker() {
+function run-editorconfig--via-docker() {
 
   # shellcheck disable=SC1091
   source ./scripts/docker/docker.lib.sh


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->

Instead of invoking `editorconfig` once, we use `xargs` to invoke `editorconfig` multiple time with batches of up to 1000 files. In the case where there are between 1 and 1000 files to be checked, we will continue to invoke `editorconfig` exactly once. In the case where there are no files to be checked, we will not invoke `editorconfig` at all; therefore we remove the `/dev/null` hack.

There are two consequences of using `xargs`.

First, we cannot run `editorconfig` via a shell function, as `xargs` cannot run shell functions. Instead we must run it via a script. I have taken the approach of having `xargs` call the same `check-file-format.sh` script that calls it, but with different flags. I am aware that some people strongly prefer having separate helper scripts for `xargs` to call. I am happy to rewrite this script in that fashion if that is your preference.

Second, instead of providing the list of files via the command line, we provide it via a pipe. This allows us to use the `-0` flag of `xargs` and the `-z` flag of the git tooling to pass the filenames as NUL terminated instead of LF terminated, and prevents spaces in filenames from being interpreted as delimiters.

In the case where we run `editorconfig` via docker, we further need to shell-escape each filename so that filenames with spaces survive being parsed by the inner shell: hence the `printf '%q '` nonsense.

My intent is to squash when I merge.

## Context

<!-- Why is this change required? What problem does it solve? -->

The BCSS team is migrating its codebase from GitLab to GitHub. As part of that, we have added the contents of this template repository to our own repositories.

We encountered two bugs:
- This script does not correctly handle filenames that contain spaces. While you could argue that filenames shouldn't contain spaces, our codebase has been worked on for two decades by mostly Windows-based developers, and has a number of files whose names contain spaces.
- This script does not correctly handle checking against a large number of files. When run with `check=all`, this script invokes `editorconfig` (possibly via docker) with the names of every file in the repository on its command line. This means that with a large enough repository, we hit the limit for the size of a process's command line and environment combined (typically 2MB on Linux but only 256KB on macOS).

This PR fixes both bugs.

The same bugs are present in the check-english-usage and check-markdown-format scripts. I'm happy to extend this PR to fix both of those scripts, or to do so in separate PRs.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
